### PR TITLE
SFR-571 Move descriptive fields to instance records

### DIFF
--- a/lib/dataModel.py
+++ b/lib/dataModel.py
@@ -61,7 +61,6 @@ class WorkRecord(DataObject):
         self.alt_titles = None
         self.sort_title = None
         self.medium = None
-        self.summary = None
         self.series = None
         self.series_position = None
         self.primary_identifier = None
@@ -95,6 +94,7 @@ class InstanceRecord(DataObject):
         self.edition_statement = None
         self.extent = None
         self.table_of_contents = None
+        self.summary = None
         self.agents = []
         self.identifiers = []
         self.formats = []

--- a/lib/marcParse.py
+++ b/lib/marcParse.py
@@ -163,7 +163,7 @@ def transformMARC(record, marcRels):
         ('520', 'summary', 'a')
     ]
     for field in tocData:
-        extractSubfieldValue(marcRecord, work, field)
+        extractSubfieldValue(marcRecord, instance, field)
 
     # Language Fields
     if len(marcRecord['546']) > 0:


### PR DESCRIPTION
This update moves the `summary` and `table_of_contents` fields to `Instance` records from `Work`s. These fields are generally edition-specific and this update allows multiple versions of each to be stored for earch work. This allows for a fuller and more accurate description of these resources, including of versions in multiple languages.