### PR TITLE
SFR-705 prep new ingest

### DIFF
--- a/lib/dataModel.py
+++ b/lib/dataModel.py
@@ -258,11 +258,11 @@ class Rights(DataObject):
         return '<Rights(license={})>'.format(self.license)
 
 class Language(DataObject):
-    def __init__(self, language=None, iso2=None, iso3=None):
+    def __init__(self, language=None, iso_2=None, iso_3=None):
         super()
         self.language = language
-        self.iso2 = iso2
-        self.iso3 = iso3
+        self.iso_2 = iso_2
+        self.iso_3 = iso_3
     
     def __repr__(self):
-        return '<Language(code={})>'.format(self.iso2)
+        return '<Language(code={})>'.format(self.iso_2)

--- a/lib/marcParse.py
+++ b/lib/marcParse.py
@@ -177,8 +177,8 @@ def transformMARC(record, marcRels):
                     continue
                 sfrLang = Language(
                     language=language,
-                    iso2=langObj.alpha_2,
-                    iso3=langObj.alpha_3
+                    iso_2=langObj.alpha_2,
+                    iso_3=langObj.alpha_3
                 )
                 work.language.append(sfrLang)
                 instance.language.append(sfrLang)

--- a/tests/test_marc.py
+++ b/tests/test_marc.py
@@ -50,7 +50,7 @@ class TestMARC(unittest.TestCase):
         )
         self.assertEqual(testWork.identifiers[0].identifier, 'doab:test')
         self.assertEqual(testWork.instances[0].rights[0].source, 'doab')
-        self.assertEqual(testWork.language[0].iso3, 'eng')
+        self.assertEqual(testWork.language[0].iso_3, 'eng')
     
     def test_agent_create(self):
         testRec = MagicMock()
@@ -331,6 +331,3 @@ class TestMARC(unittest.TestCase):
         self.assertIsInstance(testWork.instances[0], InstanceRecord)
         self.assertEqual(testWork.instances[0].summary, 'summary')
         self.assertEqual(testWork.instances[0].table_of_contents, 'table of contents')
-        print(testWork.instances[0].summary)
-
-


### PR DESCRIPTION
The DOAB ingest process would fail when a volume had a language attached due to a mismatch in the data models between this function and the persistence layer.