### PR TITLE
SFR-697 parse frontiersin links

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -12,8 +12,8 @@ aws_access_key_id:
 aws_secret_access_key:
 
 # dist_directory: dist
-timeout: 300
-memory_size: 256
+timeout: 600
+memory_size: 384
 
 # If tags are used they will overwrite all existing tags at deployment time
 #tags:

--- a/lib/dataModel.py
+++ b/lib/dataModel.py
@@ -142,7 +142,7 @@ class Format(DataObject):
 
 
 class Agent(DataObject):
-    def __init__(self, name=None, role=None, aliases=None, link=None):
+    def __init__(self, name=None, role=None, aliases=[], link=None):
         super()
         self.name = name
         self.sort_name = None

--- a/lib/linkParser.py
+++ b/lib/linkParser.py
@@ -22,7 +22,6 @@ class LinkParser:
 
     def createLinks(self):
         for link in self.parser.createLinks():
-            print(link)
             self.item.addClassItem('links', Link, **{
                 'url': link[0],
                 'media_type': link[2],

--- a/lib/linkParser.py
+++ b/lib/linkParser.py
@@ -1,0 +1,33 @@
+from lib.dataModel import Link
+
+from lib.parsers.defaultParser import DefaultParser
+from lib.parsers.frontierParser import FrontierParser
+
+class LinkParser:
+    PARSERS = [
+        FrontierParser,
+        DefaultParser
+    ]
+    def __init__(self, item, uri, media_type):
+        self.item = item
+        self.uri = uri
+        self.media_type = media_type
+    
+    def selectParser(self):
+        for model in self.PARSERS:
+            parser = model(self.uri, self.media_type)
+            if parser.validateURI() is True:
+                self.parser = parser
+                break
+
+    def createLinks(self):
+        for link in self.parser.createLinks():
+            print(link)
+            self.item.addClassItem('links', Link, **{
+                'url': link[0],
+                'media_type': link[2],
+                'flags': link[1] 
+            })
+
+
+

--- a/lib/parsers/defaultParser.py
+++ b/lib/parsers/defaultParser.py
@@ -1,0 +1,19 @@
+class DefaultParser:
+    def __init__(self, uri, media_type):
+        self.uri = uri
+        self.media_type = media_type
+    
+    def validateURI(self):
+        return True  # The "base" case that accepts all links
+    
+    def createLinks(self):
+        flags = {
+            'local': False,
+            'download': False,
+            'ebook': True,
+            'images': True
+        }
+        if 'text/html' not in self.media_type:
+            flags['download'] = True
+
+        return [(self.uri, flags, self.media_type)]

--- a/lib/parsers/frontierParser.py
+++ b/lib/parsers/frontierParser.py
@@ -30,7 +30,6 @@ class FrontierParser:
     
     def validateURI(self):
         match = re.search(self.REGEX, self.uri)
-        print(match)
         if match is not None:
             self.identifier = match.group(1)
             return True

--- a/lib/parsers/frontierParser.py
+++ b/lib/parsers/frontierParser.py
@@ -1,0 +1,44 @@
+import re
+
+
+class FrontierParser:
+    REGEX = '(?:www|journal)\.frontiersin\.org\/research-topics\/([0-9]+)\/([a-zA-Z0-9\-]+)'
+    LINK_STRINGS = {
+        'https://www.frontiersin.org/research-topics/{}/epub': {
+            'flags': {
+                'local': False,
+                'download': True,
+                'ebook': True,
+                'images': True
+            },
+            'media_type': 'application/epub+zip'
+        },
+        'https://www.frontiersin.org/research-topics/{}/pdf': {
+            'flags': {
+                'local': False,
+                'download': True,
+                'ebook': True,
+                'images': True
+            },
+            'media_type': 'application/pdf'
+        }
+    }
+
+    def __init__(self, uri, media_type):
+        self.uri = uri
+        self.media_type = media_type
+    
+    def validateURI(self):
+        match = re.search(self.REGEX, self.uri)
+        print(match)
+        if match is not None:
+            self.identifier = match.group(1)
+            return True
+        
+        return False
+    
+    def createLinks(self):
+        return [
+            (urlStr.format(self.identifier), attrs['flags'], attrs['media_type'])
+            for urlStr, attrs in self.LINK_STRINGS.items()
+        ]

--- a/tests/test_default.py
+++ b/tests/test_default.py
@@ -1,0 +1,28 @@
+import unittest
+
+
+from lib.parsers.defaultParser import DefaultParser
+
+class TestDefaultParser(unittest.TestCase):
+    def test_init(self):
+        defaultTest = DefaultParser('uri', 'type')
+        self.assertEqual(defaultTest.uri, 'uri')
+        self.assertEqual(defaultTest.media_type, 'type')
+    
+    def test_validateURI(self):
+        defaultTest = DefaultParser('uri', 'type')
+        self.assertTrue(defaultTest.validateURI())
+
+    def test_createLinks_no_download(self):
+        defaultTest = DefaultParser('uri', 'text/html')
+        testLink = defaultTest.createLinks()
+        self.assertEqual(testLink[0][0], 'uri')
+        self.assertFalse(testLink[0][1]['download'])
+        self.assertEqual(testLink[0][2], 'text/html')
+
+    def test_createLinks_download(self):
+        defaultTest = DefaultParser('uri', 'type')
+        testLink = defaultTest.createLinks()
+        self.assertEqual(testLink[0][0], 'uri')
+        self.assertTrue(testLink[0][1]['download'])
+        self.assertEqual(testLink[0][2], 'type')

--- a/tests/test_frontierParser.py
+++ b/tests/test_frontierParser.py
@@ -1,0 +1,43 @@
+import unittest
+
+from lib.parsers.frontierParser import FrontierParser
+
+
+class TestFrontierParser(unittest.TestCase):
+    def test_init(self):
+        testFront = FrontierParser('uri', 'type')
+        self.assertEqual(testFront.uri, 'uri')
+        self.assertEqual(testFront.media_type, 'type')
+    
+    def test_validateURI_success(self):
+        testFront = FrontierParser(
+            'www.frontiersin.org/research-topics/1/testing', 'testType'
+        )
+
+        outcome = testFront.validateURI()
+        self.assertTrue(outcome)
+        self.assertEqual(testFront.identifier, '1')
+
+    def test_validateURI_failure(self):
+        testFront = FrontierParser(
+            'www.other.com/test/file', 'testType'
+        )
+
+        outcome = testFront.validateURI()
+        self.assertFalse(outcome)
+    
+    def test_createLinks(self):
+        testFront = FrontierParser('uri', 'type')
+        testFront.identifier = 1
+
+        testLinks = testFront.createLinks()
+        self.assertEqual(
+            testLinks[0][0], 'https://www.frontiersin.org/research-topics/1/epub'
+        )
+        self.assertEqual(
+            testLinks[1][0], 'https://www.frontiersin.org/research-topics/1/pdf'
+        )
+        self.assertTrue(testLinks[0][1]['ebook'])
+        self.assertTrue(testLinks[1][1]['ebook'])
+        self.assertEqual(testLinks[0][2], 'application/epub+zip')
+        self.assertEqual(testLinks[1][2], 'application/pdf')

--- a/tests/test_linkParser.py
+++ b/tests/test_linkParser.py
@@ -1,0 +1,57 @@
+import unittest
+from unittest.mock import MagicMock, patch, call
+
+from lib.linkParser import LinkParser, DefaultParser, FrontierParser, Link
+
+
+class TestLinkParser(unittest.TestCase):
+    def test_init(self):
+        testParser = LinkParser('mockItem', 'mockURI', 'mockType')
+        self.assertEqual(testParser.item, 'mockItem')
+        self.assertEqual(testParser.uri, 'mockURI')
+        self.assertEqual(testParser.media_type, 'mockType')
+    
+    @patch.object(DefaultParser, 'validateURI')
+    @patch.object(FrontierParser, 'validateURI')
+    def test_selectParser_first(self, frontValidate, defaultValidate):
+        frontValidate.return_value = True
+        testParser = LinkParser('mockItem', 'mockURI', 'mockType')
+        testParser.selectParser()
+
+        frontValidate.assert_called_once()
+        defaultValidate.assert_not_called()
+        self.assertIsInstance(testParser.parser, FrontierParser)
+
+    @patch.object(DefaultParser, 'validateURI')
+    @patch.object(FrontierParser, 'validateURI')
+    def test_selectParser_last(self, frontValidate, defaultValidate):
+        frontValidate.return_value = False
+        defaultValidate.return_value = True
+        testParser = LinkParser('mockItem', 'mockURI', 'mockType')
+        testParser.selectParser()
+
+        frontValidate.assert_called_once()
+        defaultValidate.assert_called_once()
+        self.assertIsInstance(testParser.parser, DefaultParser)
+
+    def test_createLinks(self):
+        mockItem = MagicMock()
+        mockParser = MagicMock()
+        mockParser.createLinks.return_value = [
+            ('url1', 'flags1', 'type1'),
+            ('url2', 'flags2', 'type2')
+        ]
+
+        testParser = LinkParser(mockItem, 'mockURI', 'mockType')
+        testParser.parser = mockParser
+
+        testParser.createLinks()
+
+        mockItem.addClassItem.assert_has_calls([
+            call(
+                'links', Link, url='url1', media_type='type1', flags='flags1'
+            ),
+            call(
+                'links', Link, url='url2', media_type='type2', flags='flags2'
+            )
+        ])

--- a/tests/test_marc.py
+++ b/tests/test_marc.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import patch, MagicMock, call
+from unittest.mock import patch, MagicMock, call, DEFAULT
 from requests.exceptions import ConnectionError
 
 from lib.marcParse import (
@@ -12,6 +12,7 @@ from lib.marcParse import (
     parseHoldingURI
 )
 from lib.dataModel import WorkRecord, InstanceRecord
+from lib.linkParser import LinkParser
 from helpers.errorHelpers import DataError
 
 
@@ -80,7 +81,8 @@ class TestMARC(unittest.TestCase):
         ('uri1', 'text/html'),
         ('uri2', 'application/pdf')
     ])
-    def test_add_links(self, mock_parse):
+    @patch.multiple(LinkParser, selectParser=DEFAULT, createLinks=DEFAULT)
+    def test_add_links(self, mock_parse, selectParser, createLinks):
         testRec = MagicMock()
         testItem = MagicMock()
         
@@ -119,9 +121,9 @@ class TestMARC(unittest.TestCase):
         ]
 
         extractHoldingsLinks(testHoldings, testRec, testItem)
+        selectParser.assert_has_calls([call(), call()])
+        createLinks.assert_has_calls([call(), call()])
 
-        self.assertEqual(2, testItem.addClassItem.call_count)
-    
     @patch('lib.marcParse.requests')
     def test_parse_holding_success(self, mock_req):
         mock_redirect = MagicMock()


### PR DESCRIPTION
This adds a new set of parsers that read the root links after following all redirects from DOAB. If these links match a specific pattern they are reformatted to a standard that we know can provide a higher degree of utility for ResearchNow users. For the FrontiersIn links this means that we can supply a local EPUB copy as well as a downloadable PDF copy for all of their open source works.

This implements a plugin structure that makes it much easier to add parsers for additional sources in the future. There is also a "base" parser that handles any links not other wise parsed in a naive way.

Finally this adds internal VIAF processing to help with the overall performance of the backend application