### PR TITLE
SFR-697 pass filename

### DIFF
--- a/lib/linkParser.py
+++ b/lib/linkParser.py
@@ -1,4 +1,4 @@
-from lib.dataModel import Link
+from lib.dataModel import Link, Identifier
 
 from lib.parsers.defaultParser import DefaultParser
 from lib.parsers.frontierParser import FrontierParser
@@ -27,6 +27,14 @@ class LinkParser:
                 'media_type': link[2],
                 'flags': link[1] 
             })
+
+            if link[3] is not None:
+                setattr(self.item, 'fileName', link[3])
+                self.item.addClassItem('identifiers', Identifier, **{
+                    'type': 'doab',
+                    'identifier': link[3],
+                    'weight': 1
+                })
 
 
 

--- a/lib/parsers/frontierParser.py
+++ b/lib/parsers/frontierParser.py
@@ -1,4 +1,5 @@
 import re
+import requests
 
 
 class FrontierParser:
@@ -37,7 +38,24 @@ class FrontierParser:
         return False
     
     def createLinks(self):
-        return [
-            (urlStr.format(self.identifier), attrs['flags'], attrs['media_type'])
-            for urlStr, attrs in self.LINK_STRINGS.items()
-        ]
+        links = []
+        for urlStr, attrs in self.LINK_STRINGS.items():
+            outFile = None
+            if 'epub' in urlStr:
+                headReq = requests.head(urlStr.format(self.identifier))
+                if headReq.status_code == 200:
+                    try:
+                        dispHeader = headReq.headers['content-disposition']
+                        filename = re.search(r'filename=(.+)\.EPUB$', dispHeader).group(1)
+                    except AttributeError:
+                        print('Unable to load filename from {}'.format(dispHeader))
+                        continue
+                    outFile = '{}_{}.epub'.format(self.identifier, filename)
+            links.append((
+                urlStr.format(self.identifier),
+                attrs['flags'],
+                attrs['media_type'],
+                outFile
+            ))
+        
+        return links

--- a/lib/parsers/frontierParser.py
+++ b/lib/parsers/frontierParser.py
@@ -50,7 +50,9 @@ class FrontierParser:
                     except AttributeError:
                         print('Unable to load filename from {}'.format(dispHeader))
                         continue
-                    outFile = '{}_{}.epub'.format(self.identifier, filename)
+                    outFile = '{}_{}.epub'.format(
+                        self.identifier, filename.lower()
+                    )
             links.append((
                 urlStr.format(self.identifier),
                 attrs['flags'],

--- a/tests/test_frontierParser.py
+++ b/tests/test_frontierParser.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import patch, MagicMock
 
 from lib.parsers.frontierParser import FrontierParser
 
@@ -26,9 +27,17 @@ class TestFrontierParser(unittest.TestCase):
         outcome = testFront.validateURI()
         self.assertFalse(outcome)
     
-    def test_createLinks(self):
+    @patch('lib.parsers.frontierParser.requests')
+    def test_createLinks(self, mockReq):
         testFront = FrontierParser('uri', 'type')
         testFront.identifier = 1
+
+        mockResp = MagicMock()
+        mockResp.status_code = 200
+        mockResp.headers = {'content-disposition': 'attachment; filename=testing.EPUB'}
+        mockErr = MagicMock()
+        mockErr.status_code = 500
+        mockReq.head.side_effect = [mockResp, mockErr]
 
         testLinks = testFront.createLinks()
         self.assertEqual(
@@ -41,3 +50,5 @@ class TestFrontierParser(unittest.TestCase):
         self.assertTrue(testLinks[1][1]['ebook'])
         self.assertEqual(testLinks[0][2], 'application/epub+zip')
         self.assertEqual(testLinks[1][2], 'application/pdf')
+        self.assertEqual(testLinks[0][3], '1_testing.epub')
+        self.assertEqual(testLinks[1][3], None)

--- a/tests/test_linkParser.py
+++ b/tests/test_linkParser.py
@@ -1,7 +1,7 @@
 import unittest
 from unittest.mock import MagicMock, patch, call
 
-from lib.linkParser import LinkParser, DefaultParser, FrontierParser, Link
+from lib.linkParser import LinkParser, DefaultParser, FrontierParser, Link, Identifier
 
 
 class TestLinkParser(unittest.TestCase):
@@ -38,8 +38,8 @@ class TestLinkParser(unittest.TestCase):
         mockItem = MagicMock()
         mockParser = MagicMock()
         mockParser.createLinks.return_value = [
-            ('url1', 'flags1', 'type1'),
-            ('url2', 'flags2', 'type2')
+            ('url1', 'flags1', 'type1', '1_test.epub'),
+            ('url2', 'flags2', 'type2', None)
         ]
 
         testParser = LinkParser(mockItem, 'mockURI', 'mockType')
@@ -50,6 +50,9 @@ class TestLinkParser(unittest.TestCase):
         mockItem.addClassItem.assert_has_calls([
             call(
                 'links', Link, url='url1', media_type='type1', flags='flags1'
+            ),
+            call(
+                'identifiers', Identifier, type='doab', identifier='1_test.epub', weight=1
             ),
             call(
                 'links', Link, url='url2', media_type='type2', flags='flags2'


### PR DESCRIPTION
This passes a lowercased filename as a property on any item record from FrontiersIn. This allows us to explicitly set the filename for the epub version of the record, which needs to be done to create a retrievable file. The URL provided by FrontiersIn is not parseable in this way, the filename must be extracted from a `Content-Disposition` header and the logical place to do so is here.