### PR TITLE
Return None for identifier from DefaultParser

### DIFF
--- a/lib/parsers/defaultParser.py
+++ b/lib/parsers/defaultParser.py
@@ -16,4 +16,4 @@ class DefaultParser:
         if 'text/html' not in self.media_type:
             flags['download'] = True
 
-        return [(self.uri, flags, self.media_type)]
+        return [(self.uri, flags, self.media_type, None)]


### PR DESCRIPTION
The link parser accepts the possibility of storing an identifier that has been parsed from a link. Since the default parser will never do this (since it has no knowledge of the structure or the URLs that are passed to it), it simply returns None.