### PR TITLE
SFR-698 springer epub fetch

### DIFF
--- a/lib/linkParser.py
+++ b/lib/linkParser.py
@@ -2,10 +2,12 @@ from lib.dataModel import Link, Identifier
 
 from lib.parsers.defaultParser import DefaultParser
 from lib.parsers.frontierParser import FrontierParser
+from lib.parsers.springerParser import SpringerParser
 
 class LinkParser:
     PARSERS = [
         FrontierParser,
+        SpringerParser,
         DefaultParser
     ]
     def __init__(self, item, uri, media_type):

--- a/lib/parsers/springerParser.py
+++ b/lib/parsers/springerParser.py
@@ -1,0 +1,62 @@
+import re
+import requests
+
+
+class SpringerParser:
+    REGEX = 'link.springer.com\/book\/(10\.[0-9]+)\/([0-9\-]+)'
+    REDIRECT_REGEX = '((?:https?:\/\/)?link\.springer\.com\/.+)$'
+    LINK_STRINGS = {
+        'https://link.springer.com/download/epub/{}/{}.epub': {
+            'flags': {
+                'local': False,
+                'download': True,
+                'ebook': True,
+                'images': True
+            },
+            'media_type': 'application/epub+zip'
+        },
+        'https://link.springre.com/content/pdf/{}/{}.pdf': {
+            'flags': {
+                'local': False,
+                'download': False,
+                'ebook': True,
+                'images': True
+            },
+            'media_type': 'application/pdf'
+        }
+    }
+
+    def __init__(self, uri, media_type):
+        self.uri = uri
+        self.media_type = media_type
+    
+    def validateURI(self):
+        try:
+            match = re.search(self.REGEX, self.uri)
+            self.code = match.group(1)
+            self.identifier = match.group(2)
+            return True
+        except (IndexError, AttributeError):
+            redirectMatch = re.search(self.REDIRECT_REGEX, self.uri)
+            if redirectMatch:
+                self.uri = redirectMatch.group(1)
+            else:
+                return False
+            
+            if 'http' not in self.uri:
+                self.uri = 'http://{}'.format(self.uri)
+            
+            redirectHeader = requests.head(self.uri)
+            self.uri = redirectHeader.headers['Location']
+            return self.validateURI()
+
+    def createLinks(self):
+        return [
+            (
+                urlStr.format(self.code, self.identifier),
+                attrs['flags'],
+                attrs['media_type'],
+                None
+            )
+            for urlStr, attrs in self.LINK_STRINGS.items()
+        ]

--- a/lib/parsers/springerParser.py
+++ b/lib/parsers/springerParser.py
@@ -15,7 +15,7 @@ class SpringerParser:
             },
             'media_type': 'application/epub+zip'
         },
-        'https://link.springre.com/content/pdf/{}/{}.pdf': {
+        'https://link.springer.com/content/pdf/{}/{}.pdf': {
             'flags': {
                 'local': False,
                 'download': False,

--- a/tests/test_linkParser.py
+++ b/tests/test_linkParser.py
@@ -1,7 +1,9 @@
 import unittest
 from unittest.mock import MagicMock, patch, call
 
-from lib.linkParser import LinkParser, DefaultParser, FrontierParser, Link, Identifier
+from lib.linkParser import (
+    LinkParser,DefaultParser, FrontierParser, SpringerParser, Link, Identifier
+)
 
 
 class TestLinkParser(unittest.TestCase):
@@ -13,7 +15,8 @@ class TestLinkParser(unittest.TestCase):
     
     @patch.object(DefaultParser, 'validateURI')
     @patch.object(FrontierParser, 'validateURI')
-    def test_selectParser_first(self, frontValidate, defaultValidate):
+    @patch.object(SpringerParser, 'validateURI')
+    def test_selectParser_first(self, springValidate, frontValidate, defaultValidate):
         frontValidate.return_value = True
         testParser = LinkParser('mockItem', 'mockURI', 'mockType')
         testParser.selectParser()
@@ -24,8 +27,10 @@ class TestLinkParser(unittest.TestCase):
 
     @patch.object(DefaultParser, 'validateURI')
     @patch.object(FrontierParser, 'validateURI')
-    def test_selectParser_last(self, frontValidate, defaultValidate):
+    @patch.object(SpringerParser, 'validateURI')
+    def test_selectParser_last(self, springValidate, frontValidate, defaultValidate):
         frontValidate.return_value = False
+        springValidate.return_value = False
         defaultValidate.return_value = True
         testParser = LinkParser('mockItem', 'mockURI', 'mockType')
         testParser.selectParser()

--- a/tests/test_springerParser.py
+++ b/tests/test_springerParser.py
@@ -1,0 +1,64 @@
+import unittest
+from unittest.mock import patch, MagicMock
+
+from lib.parsers.springerParser import SpringerParser 
+
+
+class TestSpringerParser(unittest.TestCase):
+    def test_init(self):
+        testFront = SpringerParser('uri', 'type')
+        self.assertEqual(testFront.uri, 'uri')
+        self.assertEqual(testFront.media_type, 'type')
+    
+    def test_validateURI_success(self):
+        testSpring = SpringerParser(
+            'link.springer.com/book/10.007/123-456-7890', 'testType'
+        )
+
+        outcome = testSpring.validateURI()
+        self.assertTrue(outcome)
+        self.assertEqual(testSpring.identifier, '123-456-7890')
+        self.assertEqual(testSpring.code, '10.007')
+
+    def test_validateURI_failure(self):
+        testSpring = SpringerParser(
+            'www.other.com/test/file', 'testType'
+        )
+
+        outcome = testSpring.validateURI()
+        self.assertFalse(outcome)
+
+    @patch('lib.parsers.springerParser.requests')
+    def test_validateURI_recursive(self, mockReq):
+        testSpring = SpringerParser(
+            'link.springer.com/content?isbn=XXXX-XXXX-XXXX-XXXX', 'testType'
+        )
+
+        mockHead = MagicMock()
+        mockHead.headers = {
+            'Location': 'link.springer.com/book/10.027/999-999-999'
+        }
+        mockReq.head.return_value = mockHead
+
+        outcome = testSpring.validateURI()
+        self.assertTrue(outcome)
+        self.assertEqual(testSpring.uri, 'link.springer.com/book/10.027/999-999-999')
+    
+    def test_createLinks(self):
+        testSpring = SpringerParser('uri', 'type')
+        testSpring.code = '10.000'
+        testSpring.identifier = 1
+
+        testLinks = testSpring.createLinks()
+        self.assertEqual(
+            testLinks[0][0], 'https://link.springer.com/download/epub/10.000/1.epub'
+        )
+        self.assertEqual(
+            testLinks[1][0], 'https://link.springer.com/content/pdf/10.000/1.pdf'
+        )
+        self.assertTrue(testLinks[0][1]['ebook'])
+        self.assertTrue(testLinks[1][1]['ebook'])
+        self.assertEqual(testLinks[0][2], 'application/epub+zip')
+        self.assertEqual(testLinks[1][2], 'application/pdf')
+        self.assertEqual(testLinks[0][3], None)
+        self.assertEqual(testLinks[1][3], None)


### PR DESCRIPTION
This creates a new parser class for Springer, which has contributed several thousand works to the DOAB project. This adds another plugin for the LinkParser class and validates the URLs passed to it to see if they can be parsed into a resolvable epub link.

The end resuld should be that all links starting with `link.springer.com` should be resolved to a local ePub file and a PDF file that can be read online. Some links are fetched as `301` or `302` redirects and those need to be followed to find the correct form of the URL that can be paresd into these components.

There is a prefix on each of these links that usually is `10.007` but which sometimes varies, and therefore must be fetched via regex along with the ISBN number that uniquely identifies each work within the Springer collection (and hypothetically globally).