### PR TITLE
SFR-807 Add MDPI Parser

### DIFF
--- a/lib/linkParser.py
+++ b/lib/linkParser.py
@@ -2,12 +2,14 @@ from lib.dataModel import Link, Identifier
 
 from lib.parsers.defaultParser import DefaultParser
 from lib.parsers.frontierParser import FrontierParser
+from lib.parsers.mdpiParser import MDPIParser
 from lib.parsers.springerParser import SpringerParser
 
 class LinkParser:
     PARSERS = [
         FrontierParser,
         SpringerParser,
+        MDPIParser,
         DefaultParser
     ]
     def __init__(self, item, uri, media_type):

--- a/lib/parsers/mdpiParser.py
+++ b/lib/parsers/mdpiParser.py
@@ -1,0 +1,25 @@
+import re
+
+
+class MDPIParser:
+    REGEX = 'mdpi.com/books/pdfview/book/([0-9]+)$'
+
+    def __init__(self, uri, media_type):
+        self.uri = uri
+        self.media_type = media_type
+    
+    def validateURI(self):
+        try:
+            match = re.search(self.REGEX, self.uri)
+            self.identifier = match.group(1)
+            return True
+        except (IndexError, AttributeError):
+            return False
+
+    def createLinks(self):
+        return [(
+            self.uri.replace('pdfview', 'pdfdownload'),
+            {'local': False, 'download': True, 'ebook': True, 'images': True},
+            'application/pdf',
+            None
+        )]

--- a/tests/test_linkParser.py
+++ b/tests/test_linkParser.py
@@ -2,7 +2,8 @@ import unittest
 from unittest.mock import MagicMock, patch, call
 
 from lib.linkParser import (
-    LinkParser,DefaultParser, FrontierParser, SpringerParser, Link, Identifier
+    LinkParser, DefaultParser, FrontierParser, SpringerParser, MDPIParser,
+    Link, Identifier
 )
 
 
@@ -14,9 +15,10 @@ class TestLinkParser(unittest.TestCase):
         self.assertEqual(testParser.media_type, 'mockType')
     
     @patch.object(DefaultParser, 'validateURI')
+    @patch.object(MDPIParser, 'validateURI')
     @patch.object(FrontierParser, 'validateURI')
     @patch.object(SpringerParser, 'validateURI')
-    def test_selectParser_first(self, springValidate, frontValidate, defaultValidate):
+    def test_selectParser_first(self, springValidate, frontValidate, mdpiValidate, defaultValidate):
         frontValidate.return_value = True
         testParser = LinkParser('mockItem', 'mockURI', 'mockType')
         testParser.selectParser()
@@ -26,11 +28,13 @@ class TestLinkParser(unittest.TestCase):
         self.assertIsInstance(testParser.parser, FrontierParser)
 
     @patch.object(DefaultParser, 'validateURI')
+    @patch.object(MDPIParser, 'validateURI')
     @patch.object(FrontierParser, 'validateURI')
     @patch.object(SpringerParser, 'validateURI')
-    def test_selectParser_last(self, springValidate, frontValidate, defaultValidate):
+    def test_selectParser_last(self, springValidate, frontValidate, mdpiValidate, defaultValidate):
         frontValidate.return_value = False
         springValidate.return_value = False
+        mdpiValidate.return_value = False
         defaultValidate.return_value = True
         testParser = LinkParser('mockItem', 'mockURI', 'mockType')
         testParser.selectParser()

--- a/tests/test_mdpiParser.py
+++ b/tests/test_mdpiParser.py
@@ -1,0 +1,40 @@
+import unittest
+from unittest.mock import patch, MagicMock
+
+from lib.parsers.mdpiParser import MDPIParser
+
+
+class TestMDPIParser(unittest.TestCase):
+    def test_init(self):
+        testMDPI = MDPIParser('uri', 'type')
+        self.assertEqual(testMDPI.uri, 'uri')
+        self.assertEqual(testMDPI.media_type, 'type')
+    
+    def test_validateURI_success(self):
+        testMDPI = MDPIParser(
+            'mdpi.com/books/pdfview/book/1', 'testType'
+        )
+
+        outcome = testMDPI.validateURI()
+        self.assertTrue(outcome)
+        self.assertEqual(testMDPI.identifier, '1')
+
+    def test_validateURI_failure(self):
+        testMDPI = MDPIParser(
+            'www.other.com/test/file', 'testType'
+        )
+
+        outcome = testMDPI.validateURI()
+        self.assertFalse(outcome)
+    
+    def test_createLinks(self):
+        testMDPI = MDPIParser('mdpi.com/books/pdfview/book/1', 'type')
+        testMDPI.identifier = 1
+
+        testLinks = testMDPI.createLinks()
+        self.assertEqual(
+            testLinks[0][0], 'mdpi.com/books/pdfdownload/book/1'
+        )
+        self.assertTrue(testLinks[0][1]['ebook'])
+        self.assertTrue(testLinks[0][1]['download'])
+        self.assertEqual(testLinks[0][2], 'application/pdf')


### PR DESCRIPTION
This adds a new class for parsing MDPI links. The conversion from the basic HTML page to a downloadable PDF link is simple and can be done with a simple `replace` call, which returns a single link. It would be good to provide a "Read Online" link for these books, but as our access is currently blocked this allows us to give users easy access.