### PR TITLE
SFR-814 add open edition parser

### DIFF
--- a/lib/linkParser.py
+++ b/lib/linkParser.py
@@ -1,14 +1,15 @@
 from lib.dataModel import Link, Identifier
+from .parsers import (
+    DefaultParser, FrontierParser, MDPIParser,
+    OpenEditionParser, SpringerParser
+)
 
-from lib.parsers.defaultParser import DefaultParser
-from lib.parsers.frontierParser import FrontierParser
-from lib.parsers.mdpiParser import MDPIParser
-from lib.parsers.springerParser import SpringerParser
 
 class LinkParser:
     PARSERS = [
         FrontierParser,
         SpringerParser,
+        OpenEditionParser,
         MDPIParser,
         DefaultParser
     ]

--- a/lib/parsers/__init__.py
+++ b/lib/parsers/__init__.py
@@ -1,0 +1,5 @@
+from .defaultParser import DefaultParser
+from .frontierParser import FrontierParser
+from .mdpiParser import MDPIParser
+from .openEditionParser import OpenEditionParser
+from .springerParser import SpringerParser

--- a/lib/parsers/openEditionParser.py
+++ b/lib/parsers/openEditionParser.py
@@ -1,0 +1,93 @@
+import re
+import requests
+
+from bs4 import BeautifulSoup
+
+
+class OpenEditionParser:
+    OE_URL_ROOT = 'books.openedition.org'
+    REGEX = r'books.openedition.org/([a-z0-9]+)/([0-9]+)$'
+    OPTION_REGEXES = [
+        r'\/(epub\/[0-9]+)', r'\/(pdf\/[0-9]+)', r'([0-9]+\?format=reader)$', r'^([0-9]+)$'
+    ]
+    FORMAT_ATTRS = [
+        {
+            'media_type': 'application/epub+zip',
+            'flags': {'local': False, 'download': True, 'images': True, 'ebook': True}
+        },
+        {
+            'media_type': 'application/pdf',
+            'flags': {'local': False, 'download': True, 'images': True, 'ebook': True}
+        },
+        {
+            'media_type': 'text/html',
+            'flags': {'local': False, 'download': False, 'images': True, 'ebook': True}
+        },
+        {
+            'media_type': 'text/html',
+            'flags': {'local': False, 'download': False, 'images': True, 'ebook': True}
+        }
+    ]
+
+    def __init__(self, uri, media_type):
+        self.uri = uri
+        self.media_type = media_type
+    
+    @property
+    def uri(self):
+        return self._uri
+    
+    @uri.setter
+    def uri(self, value):
+        if value[:4] == 'http':
+            self._uri = value
+        else:
+            self._uri = 'http://{}'.format(value)
+    
+    def validateURI(self):
+        match = re.search(self.REGEX, self.uri)
+        if match is not None:
+            if match.start() > 8:
+                self.uri = self.uri[match.start():]
+            self.publisher = match.group(1)
+            self.identifier = match.group(2)
+            return True
+        
+        return False
+    
+    def createLinks(self):
+        options = []
+        oePage = requests.get(self.uri)
+        if oePage.status_code == 200:
+            for link in self.loadEbookLinks(oePage.text):
+                self.parseBookLink(options, link)
+
+        return self.getBestLink(options)
+            
+
+    def loadEbookLinks(self, oeHTML):
+        oeSoup = BeautifulSoup(oeHTML, 'html.parser')
+        accessEl = oeSoup.find(id='book-access')
+        return accessEl.find_all('a')
+    
+    def parseBookLink(self, options, link):
+        relLink = link.get('href')
+        for i, regex in enumerate(self.OPTION_REGEXES):
+            typeMatch = re.search(regex, relLink)
+            if typeMatch:
+                formatAttrs = self.FORMAT_ATTRS[i]
+                options.append((
+                    i,
+                    '{}/{}/{}'.format(self.OE_URL_ROOT, self.publisher, typeMatch.group(1)),
+                    formatAttrs['flags'],
+                    formatAttrs['media_type'],
+                    None
+                ))
+    
+    def getBestLink(self, options):
+        options.sort(key=lambda x: x[0])
+        try:
+            topOption = options[0]
+            return topOption[1:]
+        except IndexError:
+            return []

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+beautifulsoup
 boto3
 lxml
 marcalyx

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-beautifulsoup
+beautifulsoup4
 boto3
 lxml
 marcalyx

--- a/tests/test_linkParser.py
+++ b/tests/test_linkParser.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, patch, call
 
 from lib.linkParser import (
     LinkParser, DefaultParser, FrontierParser, SpringerParser, MDPIParser,
-    Link, Identifier
+    OpenEditionParser, Link, Identifier
 )
 
 
@@ -14,26 +14,38 @@ class TestLinkParser(unittest.TestCase):
         self.assertEqual(testParser.uri, 'mockURI')
         self.assertEqual(testParser.media_type, 'mockType')
     
+    @patch.object(OpenEditionParser, 'validateURI')
     @patch.object(DefaultParser, 'validateURI')
     @patch.object(MDPIParser, 'validateURI')
     @patch.object(FrontierParser, 'validateURI')
     @patch.object(SpringerParser, 'validateURI')
-    def test_selectParser_first(self, springValidate, frontValidate, mdpiValidate, defaultValidate):
+    def test_selectParser_first(
+        self, springValidate, frontValidate, mdpiValidate, defaultValidate,
+        openEdValidate
+    ):
         frontValidate.return_value = True
         testParser = LinkParser('mockItem', 'mockURI', 'mockType')
         testParser.selectParser()
 
         frontValidate.assert_called_once()
+        springValidate.assert_not_called()
+        openEdValidate.assert_not_called()
+        mdpiValidate.assert_not_called()
         defaultValidate.assert_not_called()
         self.assertIsInstance(testParser.parser, FrontierParser)
 
+    @patch.object(OpenEditionParser, 'validateURI')
     @patch.object(DefaultParser, 'validateURI')
     @patch.object(MDPIParser, 'validateURI')
     @patch.object(FrontierParser, 'validateURI')
     @patch.object(SpringerParser, 'validateURI')
-    def test_selectParser_last(self, springValidate, frontValidate, mdpiValidate, defaultValidate):
+    def test_selectParser_last(
+        self, springValidate, frontValidate, mdpiValidate, defaultValidate,
+        openEdValidate
+    ):
         frontValidate.return_value = False
         springValidate.return_value = False
+        openEdValidate.return_value = False
         mdpiValidate.return_value = False
         defaultValidate.return_value = True
         testParser = LinkParser('mockItem', 'mockURI', 'mockType')

--- a/tests/test_openEditionParser.py
+++ b/tests/test_openEditionParser.py
@@ -1,0 +1,132 @@
+import unittest
+from unittest.mock import patch, MagicMock, DEFAULT, call
+
+from lib.parsers import OpenEditionParser
+
+
+class TestOpenEditionParser(unittest.TestCase):
+    def test_init(self):
+        testFront = OpenEditionParser('uri', 'type')
+        self.assertEqual(testFront.uri, 'http://uri')
+        self.assertEqual(testFront.media_type, 'type')
+    
+    def test_init_withHTTP(self):
+        testFront = OpenEditionParser('http://uri', 'type')
+        self.assertEqual(testFront.uri, 'http://uri')
+        self.assertEqual(testFront.media_type, 'type')
+    
+    def test_validateURI_success(self):
+        testSpring = OpenEditionParser(
+            'externallinkservice.com?url=books.openedition.org/test/123', 'testType'
+        )
+
+        outcome = testSpring.validateURI()
+        self.assertTrue(outcome)
+        self.assertEqual(testSpring.publisher, 'test')
+        self.assertEqual(testSpring.identifier, '123')
+
+    def test_validateURI_failure(self):
+        testSpring = OpenEditionParser(
+            'www.other.com/test/file', 'testType'
+        )
+
+        outcome = testSpring.validateURI()
+        self.assertFalse(outcome)
+
+    @patch.multiple(
+        OpenEditionParser,
+        loadEbookLinks=DEFAULT,
+        parseBookLink=DEFAULT,
+        getBestLink=DEFAULT
+    )
+    @patch('lib.parsers.openEditionParser.requests')
+    def test_createLinks_success(self, mockReq, loadEbookLinks, parseBookLink, getBestLink):
+        testSpring = OpenEditionParser('uri', 'type')
+        testSpring.uri = 'openedition.org/test/123'
+
+        oeResp = MagicMock()
+        oeResp.status_code = 200
+        oeResp.text = 'mock_html_content'
+
+        mockReq.get.return_value = oeResp
+
+        loadEbookLinks.return_value = ['link1', 'link2']
+        getBestLink.return_value = True
+
+        testLinks = testSpring.createLinks()
+        self.assertTrue(testLinks)
+        mockReq.get.assert_called_once_with('http://openedition.org/test/123')
+        loadEbookLinks.assert_called_once_with('mock_html_content')
+        parseBookLink.assert_has_calls([
+            call([], 'link1'), call([], 'link2')
+        ])
+        getBestLink.assert_called_once_with([])
+    
+    @patch.object(OpenEditionParser, 'getBestLink', return_value=False)
+    @patch('lib.parsers.openEditionParser')
+    def test_createLinks_failure(self, mockReq, mockGetBest):
+        testSpring = OpenEditionParser('uri', 'type')
+        testSpring.uri = 'openedition.org/test/123'
+
+        oeResp = MagicMock()
+        oeResp.status_code = 404
+
+        self.assertFalse(testSpring.createLinks())
+    
+    def test_loadEbookLinks_found(self):
+        mockHTML = """<html>
+        <head>
+            <title>HTML Test Page With Links</title>
+        </head>
+        <body>
+            <div class="open-edition-body">
+                <div id="book-access">
+                    <a href="test1">Testing</a>
+                    <a href="test2">Testing</a>
+                    <a href="test3">Testing</a>
+                </div>
+            </div>
+        </body>
+        </html>
+        """
+
+        testSpring = OpenEditionParser('uri', 'type')
+        linkList = testSpring.loadEbookLinks(mockHTML)
+        self.assertEqual(len(linkList), 3)
+        self.assertEqual(linkList[1].get('href'), 'test2')
+    
+    def test_parseBookLink_foundMatch(self):
+        testSpring = OpenEditionParser('uri', 'type')
+        testSpring.publisher = 'test'
+
+        testOptions = []
+        mockLink = MagicMock()
+        mockLink.get.return_value = 'books.openedition.org/epub/123'
+
+        testSpring.parseBookLink(testOptions, mockLink)
+
+        self.assertEqual(len(testOptions), 1)
+        self.assertEqual(testOptions[0][3], 'application/epub+zip')
+
+    def test_parseBookLink_noMatch(self):
+        testSpring = OpenEditionParser('uri', 'type')
+
+        testOptions = []
+        mockLink = MagicMock()
+        mockLink.get.return_value = 'books.openedition.org/something/123'
+
+        testSpring.parseBookLink(testOptions, mockLink)
+
+        self.assertEqual(len(testOptions), 0)
+
+    def test_getBestLink_success(self):
+        testSpring = OpenEditionParser('uri', 'type')
+        testOptions = [(3, 'test3'), (1, 'test1'), (2, 'test2')]
+        testMatch = testSpring.getBestLink(testOptions)
+        self.assertEqual(testMatch[0], 'test1')
+
+    def test_getBestLink_none(self):
+        testSpring = OpenEditionParser('uri', 'type')
+        testOptions = []
+        testMatch = testSpring.getBestLink(testOptions)
+        self.assertEqual(testMatch, [])


### PR DESCRIPTION
OpenEditions is a major contributor of, mainly French, books to the DOAB project. These come from a range of publishers, but are all made available through a standard UI. These books have different levels of access from an open access page on the OE website, to a downloadable epub file. There is no API for querying for the existence of these different versions, so the HTML of the page that represents the book record must be parsed.

This is done so using the `BeatifulSoup` parser and extracts the relevant links. If epubs are found they are passed to that processing pipeline.