### PR TITLE
SFR-814 Add identifier to OpenEdition epubs

### DIFF
--- a/lib/parsers/openEditionParser.py
+++ b/lib/parsers/openEditionParser.py
@@ -81,7 +81,7 @@ class OpenEditionParser:
                     '{}/{}/{}'.format(self.OE_URL_ROOT, self.publisher, typeMatch.group(1)),
                     formatAttrs['flags'],
                     formatAttrs['media_type'],
-                    None
+                    '{}_{}.epub'.format(self.publisher, self.identifier)
                 ))
     
     def getBestLink(self, options):

--- a/tests/test_openEditionParser.py
+++ b/tests/test_openEditionParser.py
@@ -98,6 +98,7 @@ class TestOpenEditionParser(unittest.TestCase):
     def test_parseBookLink_foundMatch(self):
         testSpring = OpenEditionParser('uri', 'type')
         testSpring.publisher = 'test'
+        testSpring.identifier = '123'
 
         testOptions = []
         mockLink = MagicMock()
@@ -107,6 +108,7 @@ class TestOpenEditionParser(unittest.TestCase):
 
         self.assertEqual(len(testOptions), 1)
         self.assertEqual(testOptions[0][3], 'application/epub+zip')
+        self.assertEqual(testOptions[0][4], 'test_123.epub')
 
     def test_parseBookLink_noMatch(self):
         testSpring = OpenEditionParser('uri', 'type')


### PR DESCRIPTION
This adds a `doab` identifier for OpenEdition epub files. This is necessary for the newly created epub file to match with the existing item record and provide access through the UI.